### PR TITLE
fix: improve GPU VRAM detection for high-memory cards

### DIFF
--- a/Optiscaler-Manager.sln
+++ b/Optiscaler-Manager.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OptiscalerClient", "OptiscalerClient.csproj", "{83E0DABA-3437-DB2B-0B86-C530B9365BF9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{83E0DABA-3437-DB2B-0B86-C530B9365BF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{83E0DABA-3437-DB2B-0B86-C530B9365BF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{83E0DABA-3437-DB2B-0B86-C530B9365BF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{83E0DABA-3437-DB2B-0B86-C530B9365BF9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A84E4131-380F-4888-9822-622F48BD9A1D}
+	EndGlobalSection
+EndGlobal

--- a/Services/GpuDetectionService.cs
+++ b/Services/GpuDetectionService.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Linq;
-using System.Management;
+﻿using System.Management;
+using Microsoft.Win32;
 
 namespace OptiscalerClient.Services
 {
@@ -24,7 +23,7 @@ namespace OptiscalerClient.Services
         public GpuVendor Vendor { get; set; } = GpuVendor.Unknown;
         public string DriverVersion { get; set; } = string.Empty;
         public ulong VideoMemoryBytes { get; set; }
-        
+
         public string VideoMemoryGB => $"{VideoMemoryBytes / (1024.0 * 1024.0 * 1024.0):F1} GB";
     }
 
@@ -41,36 +40,29 @@ namespace OptiscalerClient.Services
             try
             {
                 var gpus = new System.Collections.Generic.List<GpuInfo>();
-                
+
                 using (var searcher = new ManagementObjectSearcher("SELECT * FROM Win32_VideoController"))
                 {
                     foreach (ManagementObject obj in searcher.Get())
                     {
                         var gpu = new GpuInfo();
-                        
+
                         // Get GPU name
                         gpu.Name = obj["Name"]?.ToString() ?? "Unknown GPU";
-                        
+
                         // Detect vendor from name
                         gpu.Vendor = DetectVendorFromName(gpu.Name);
-                        
+
                         // Get driver version
                         gpu.DriverVersion = obj["DriverVersion"]?.ToString() ?? "Unknown";
-                        
-                        // Get video memory (in bytes)
-                        if (obj["AdapterRAM"] != null)
-                        {
-                            try
-                            {
-                                gpu.VideoMemoryBytes = Convert.ToUInt64(obj["AdapterRAM"]);
-                            }
-                            catch { }
-                        }
-                        
+
+                        // Get video memory (in bytes) using WMI + registry fallback.
+                        gpu.VideoMemoryBytes = GetBestVideoMemoryBytes(obj, gpu.Name);
+
                         gpus.Add(gpu);
                     }
                 }
-                
+
                 return gpus.ToArray();
             }
             catch
@@ -94,23 +86,23 @@ namespace OptiscalerClient.Services
         public GpuInfo? GetDiscreteGPU()
         {
             var gpus = DetectGPUs();
-            
+
             // Filter out integrated GPUs (usually have less VRAM)
             var discreteGpus = gpus.Where(g => g.VideoMemoryBytes > 2L * 1024 * 1024 * 1024).ToArray(); // > 2GB
-            
+
             if (discreteGpus.Length == 0)
                 return gpus.Length > 0 ? gpus[0] : null;
-            
+
             // Prefer NVIDIA, then AMD, then Intel
             var nvidia = discreteGpus.FirstOrDefault(g => g.Vendor == GpuVendor.NVIDIA);
             if (nvidia != null) return nvidia;
-            
+
             var amd = discreteGpus.FirstOrDefault(g => g.Vendor == GpuVendor.AMD);
             if (amd != null) return amd;
-            
+
             var intel = discreteGpus.FirstOrDefault(g => g.Vendor == GpuVendor.Intel);
             if (intel != null) return intel;
-            
+
             return discreteGpus[0];
         }
 
@@ -121,40 +113,40 @@ namespace OptiscalerClient.Services
         {
             if (string.IsNullOrEmpty(gpuName))
                 return GpuVendor.Unknown;
-            
+
             var nameLower = gpuName.ToLowerInvariant();
-            
+
             // NVIDIA detection
-            if (nameLower.Contains("nvidia") || 
-                nameLower.Contains("geforce") || 
-                nameLower.Contains("quadro") || 
+            if (nameLower.Contains("nvidia") ||
+                nameLower.Contains("geforce") ||
+                nameLower.Contains("quadro") ||
                 nameLower.Contains("tesla") ||
                 nameLower.Contains("rtx") ||
                 nameLower.Contains("gtx"))
             {
                 return GpuVendor.NVIDIA;
             }
-            
+
             // AMD detection
-            if (nameLower.Contains("amd") || 
-                nameLower.Contains("radeon") || 
+            if (nameLower.Contains("amd") ||
+                nameLower.Contains("radeon") ||
                 nameLower.Contains("rx ") ||
                 nameLower.Contains("vega") ||
                 nameLower.Contains("navi"))
             {
                 return GpuVendor.AMD;
             }
-            
+
             // Intel detection
-            if (nameLower.Contains("intel") || 
-                nameLower.Contains("iris") || 
+            if (nameLower.Contains("intel") ||
+                nameLower.Contains("iris") ||
                 nameLower.Contains("uhd graphics") ||
                 nameLower.Contains("hd graphics") ||
                 nameLower.Contains("arc"))
             {
                 return GpuVendor.Intel;
             }
-            
+
             return GpuVendor.Unknown;
         }
 
@@ -173,19 +165,135 @@ namespace OptiscalerClient.Services
         public string GetGPUDescription()
         {
             var gpus = DetectGPUs();
-            
+
             if (gpus.Length == 0)
                 return "No GPU detected";
-            
+
             if (gpus.Length == 1)
                 return $"{GetVendorIcon(gpus[0].Vendor)} {gpus[0].Name}";
-            
+
             // Multiple GPUs
             var discrete = GetDiscreteGPU();
             if (discrete != null)
                 return $"{GetVendorIcon(discrete.Vendor)} {discrete.Name} (+{gpus.Length - 1} more)";
-            
+
             return $"{gpus.Length} GPUs detected";
+        }
+
+        /// <summary>
+        /// Gets the best available video memory in bytes for a given GPU
+        /// </summary>
+        private ulong GetBestVideoMemoryBytes(ManagementObject gpuObject, string gpuName)
+        {
+            var adapterRamBytes = TryGetAdapterRam(gpuObject);
+            var registryBytes = TryGetVideoMemoryFromRegistry(gpuName);
+
+            if (adapterRamBytes == 0)
+                return registryBytes;
+
+            if (registryBytes == 0)
+                return adapterRamBytes;
+
+            // Some systems cap AdapterRAM around ~4 GB for larger cards.
+            return Math.Max(adapterRamBytes, registryBytes);
+        }
+
+        private ulong TryGetAdapterRam(ManagementObject gpuObject)
+        {
+            try
+            {
+                if (gpuObject["AdapterRAM"] == null)
+                    return 0;
+
+                return Convert.ToUInt64(gpuObject["AdapterRAM"]);
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        private ulong TryGetVideoMemoryFromRegistry(string gpuName)
+        {
+            try
+            {
+                using var videoRoot = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Control\Video");
+                if (videoRoot == null)
+                    return 0;
+
+                foreach (var adapterGuid in videoRoot.GetSubKeyNames())
+                {
+                    using var adapterKey = videoRoot.OpenSubKey(adapterGuid);
+                    if (adapterKey == null)
+                        continue;
+
+                    foreach (var childName in adapterKey.GetSubKeyNames())
+                    {
+                        if (!childName.StartsWith("0", StringComparison.Ordinal))
+                            continue;
+
+                        using var settingsKey = adapterKey.OpenSubKey(childName);
+                        if (settingsKey == null)
+                            continue;
+
+                        var adapterString = settingsKey.GetValue("HardwareInformation.AdapterString")?.ToString();
+                        var driverDesc = settingsKey.GetValue("DriverDesc")?.ToString();
+
+                        if (!IsGpuNameMatch(gpuName, adapterString, driverDesc))
+                            continue;
+
+                        var value = settingsKey.GetValue("HardwareInformation.qwMemorySize");
+                        var bytes = TryConvertRegistryMemoryValue(value);
+                        if (bytes > 0)
+                            return bytes;
+                    }
+                }
+            }
+            catch
+            {
+                // Ignore registry read errors and fallback to WMI value.
+            }
+
+            return 0;
+        }
+
+        private bool IsGpuNameMatch(string gpuName, string? adapterString, string? driverDesc)
+        {
+            if (string.IsNullOrWhiteSpace(gpuName))
+                return true;
+
+            return ContainsIgnoreCase(gpuName, adapterString)
+                || ContainsIgnoreCase(gpuName, driverDesc)
+                || ContainsIgnoreCase(adapterString, gpuName)
+                || ContainsIgnoreCase(driverDesc, gpuName);
+        }
+
+        private bool ContainsIgnoreCase(string? left, string? right)
+        {
+            if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
+                return false;
+
+            return left.IndexOf(right, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private ulong TryConvertRegistryMemoryValue(object? value)
+        {
+            try
+            {
+                return value switch
+                {
+                    ulong u => u,
+                    long l when l > 0 => (ulong)l,
+                    uint ui => ui,
+                    int i when i > 0 => (ulong)i,
+                    byte[] bytes when bytes.Length >= 8 => BitConverter.ToUInt64(bytes, 0),
+                    _ => 0
+                };
+            }
+            catch
+            {
+                return 0;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Use Windows registry (HardwareInformation.qwMemorySize) as a primary VRAM source when available, with WMI (AdapterRAM) kept as fallback.
This avoids the ~4 GB cap seen on some GPUs and improves discrete GPU detection reliability.
The change is isolated to GPU detection and preserves safe fallbacks when registry data is missing or inaccessible.