### PR TITLE
feat: add Linux support with Steam-only game scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,11 @@ TestResult.xml
 nunit-*.xml
 # Application logs and local errors
 error_log.txt
+crash.log
+
+# Runtime-generated update scripts
+update.bat
+update.sh
 
 # User-specific project settings
 *.csproj.user

--- a/Languages/Strings.en.axaml
+++ b/Languages/Strings.en.axaml
@@ -57,6 +57,8 @@
     <x:String x:Key="TxtRemoveGameTitle">Remove Game</x:String>
     <x:String x:Key="TxtRemoveGameConfirm">Are you sure you want to remove '{0}' from the list?</x:String>
 
+    <x:String x:Key="TxtLinuxSteamOnlyNotice">Running on Linux: only Steam games are detected automatically. Other platforms are not supported.</x:String>
+
     <!-- ManageCacheWindow -->
     <x:String x:Key="TxtManageCacheTitle">Manage Local Versions</x:String>
     <x:String x:Key="TxtLocalVersions">Local Versions</x:String>

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GitHub Release](https://img.shields.io/github/v/release/Agustinm28/Optiscaler-Client?style=flat-square&color=8A2BE2)](https://github.com/Agustinm28/Optiscaler-Client/releases/tag/OptiscalerClient-1.0.4)
 [![License: GPL-3.0-or-later](https://img.shields.io/badge/License-GPL--3.0--or--later-yellow.svg?style=flat-square)](LICENSE)
 [![Platform: Windows](https://img.shields.io/badge/Platform-Windows-0078D4?style=flat-square&logo=windows)](https://www.microsoft.com/windows)
+[![Platform: Linux](https://img.shields.io/badge/Platform-Linux%20(Steam)-E95420?style=flat-square&logo=linux)](https://www.linux.org)
 
 > **⚠️ Disclaimer:** This is **not** an official OptiScaler project. I am not affiliated with the OptiScaler team. This is a personal project developed without any commercial purpose. Anyone is free to try and use this software at their own risk.
 
@@ -30,7 +31,7 @@
 
 ### Game Discovery
 
-- **Multi-Platform Auto-Scanner** — Scans **Steam, Epic Games, GOG, EA, Ubisoft, Battle.net, and Xbox/Microsoft Store** libraries in parallel.
+- **Multi-Platform Auto-Scanner** — Scans **Steam, Epic Games, GOG, EA, Ubisoft, Battle.net, and Xbox/Microsoft Store** libraries in parallel. On Linux, only Steam is scanned automatically.
 - **Custom Folder Scanning** — Add any folder as a scan source for DRM-free or standalone games.
 - **Manual Game Addition** — Add games by selecting the executable directly.
 - **Drive Root Filtering** — Limit scanning to specific drives.
@@ -131,7 +132,7 @@ Full interface translation in **14 languages**:
 
 1. Download the latest version from the [Releases](https://github.com/Agustinm28/Optiscaler-Client/releases) page.
 2. Run `OptiscalerClient.exe`.
-3. **Requirements**: Windows 10/11 is required. The app is self-contained, so no external .NET runtime installation is needed.
+3. **Requirements**: Windows 10/11 is required. Linux is supported with Steam-only game scanning. The app is self-contained, so no external .NET runtime installation is needed.
 
 ---
 

--- a/Services/AppUpdateService.cs
+++ b/Services/AppUpdateService.cs
@@ -287,10 +287,12 @@ namespace OptiscalerClient.Services
                     Directory.Delete(innerDir, true);
                 }
 
-                // Create the batch script
-                var basePath = AppContext.BaseDirectory.TrimEnd('\\');
-                var batPath = Path.Combine(basePath, "update.bat");
-                var batContent = $@"@echo off
+                // Create the update script (platform-specific)
+                if (OperatingSystem.IsWindows())
+                {
+                    var basePath = AppContext.BaseDirectory.TrimEnd('\\');
+                    var batPath = Path.Combine(basePath, "update.bat");
+                    var batContent = $@"@echo off
 echo Updating Optiscaler Client...
 timeout /t 2 /nobreak > nul
 cd /d ""{basePath}""
@@ -299,7 +301,24 @@ rmdir /s /q ""{updateFolder}""
 start """" ""OptiscalerClient.exe""
 del ""%~f0""
 ";
-                File.WriteAllText(batPath, batContent);
+                    File.WriteAllText(batPath, batContent);
+                }
+                else
+                {
+                    var basePath = AppContext.BaseDirectory.TrimEnd('/');
+                    var shPath = Path.Combine(basePath, "update.sh");
+                    var shContent = $@"#!/bin/sh
+echo 'Updating Optiscaler Client...'
+sleep 2
+cp -rf ""{updateFolder}/""* ""{basePath}/""
+rm -rf ""{updateFolder}""
+""{basePath}/OptiscalerClient"" &
+rm -- ""$0""
+";
+                    File.WriteAllText(shPath, shContent);
+                    File.SetUnixFileMode(shPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                        | UnixFileMode.GroupRead | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+                }
             }
             finally
             {
@@ -310,18 +329,35 @@ del ""%~f0""
 
         public void FinalizeAndRestart()
         {
-            var batPath = Path.Combine(AppContext.BaseDirectory, "update.bat");
-            if (File.Exists(batPath))
+            string scriptPath;
+            ProcessStartInfo psi;
+
+            if (OperatingSystem.IsWindows())
             {
-                var psi = new ProcessStartInfo
+                scriptPath = Path.Combine(AppContext.BaseDirectory, "update.bat");
+                if (!File.Exists(scriptPath)) return;
+                psi = new ProcessStartInfo
                 {
-                    FileName = batPath,
+                    FileName = scriptPath,
                     UseShellExecute = true,
                     CreateNoWindow = true,
                     WindowStyle = ProcessWindowStyle.Hidden
                 };
-                Process.Start(psi);
             }
+            else
+            {
+                scriptPath = Path.Combine(AppContext.BaseDirectory, "update.sh");
+                if (!File.Exists(scriptPath)) return;
+                psi = new ProcessStartInfo
+                {
+                    FileName = "/bin/sh",
+                    Arguments = scriptPath,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+            }
+
+            Process.Start(psi);
             // Avalonia UI TODO: System.Windows.Application.Current.Shutdown();
         }
     }

--- a/Services/GameAnalyzerService.cs
+++ b/Services/GameAnalyzerService.cs
@@ -430,22 +430,114 @@ public class GameAnalyzerService
 
             // ProductVersion is usually more accurate for libraries like DLSS (e.g. "3.7.10.0")
             // FileVersion might be "1.0.0.0" wrapper.
+            string? version = null;
             if (!string.IsNullOrEmpty(info.ProductVersion) && info.ProductVersion != "1.0.0.0" && !info.ProductVersion.StartsWith("1.0."))
-            {
-                return info.ProductVersion.Replace(',', '.').Split(' ')[0];
-            }
+                version = info.ProductVersion.Replace(',', '.').Split(' ')[0];
+            else if (!string.IsNullOrEmpty(info.FileVersion))
+                version = info.FileVersion.Replace(',', '.').Split(' ')[0];
+            else
+                version = $"{info.FileMajorPart}.{info.FileMinorPart}.{info.FileBuildPart}.{info.FilePrivatePart}";
 
-            if (!string.IsNullOrEmpty(info.FileVersion))
-            {
-                return info.FileVersion.Replace(',', '.').Split(' ')[0];
-            }
+            // On Linux, FileVersionInfo cannot read Windows PE version resources — fall back to manual PE parsing
+            if (version == "0.0.0.0" && !OperatingSystem.IsWindows())
+                version = ReadPeFileVersion(filePath);
 
-            return $"{info.FileMajorPart}.{info.FileMinorPart}.{info.FileBuildPart}.{info.FilePrivatePart}";
+            return version;
         }
         catch
         {
-            return "0.0.0.0";
+            return OperatingSystem.IsWindows() ? "0.0.0.0" : ReadPeFileVersion(filePath);
         }
+    }
+
+    /// <summary>
+    /// Reads the file version from a Windows PE binary by parsing the resource section directly.
+    /// Used on Linux where FileVersionInfo cannot parse PE version resources.
+    /// </summary>
+    private static string ReadPeFileVersion(string filePath)
+    {
+        try
+        {
+            using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var reader = new BinaryReader(fs);
+
+            // DOS header: MZ signature + e_lfanew at offset 0x3C
+            if (reader.ReadUInt16() != 0x5A4D) return "0.0.0.0";
+            fs.Seek(0x3C, SeekOrigin.Begin);
+            var peOffset = reader.ReadUInt32();
+
+            // PE signature
+            fs.Seek(peOffset, SeekOrigin.Begin);
+            if (reader.ReadUInt32() != 0x00004550) return "0.0.0.0";
+
+            // COFF header
+            reader.ReadUInt16(); // Machine
+            var numSections = reader.ReadUInt16();
+            reader.ReadBytes(12); // TimeDateStamp, PointerToSymbolTable, NumberOfSymbols
+            var optHeaderSize = reader.ReadUInt16();
+            reader.ReadUInt16(); // Characteristics
+
+            // Optional header
+            var optHeaderStart = fs.Position;
+            var magic = reader.ReadUInt16();
+            bool is64 = magic == 0x20B; // PE32+ vs PE32
+
+            // DataDirectory[2] = Resource Table
+            // PE32:  DataDirectory starts at offset 96 → resource at 96 + 2*8 = 112
+            // PE32+: DataDirectory starts at offset 112 → resource at 112 + 2*8 = 128
+            var resourceDirOffset = (is64 ? 112 : 96) + 16;
+            fs.Seek(optHeaderStart + resourceDirOffset, SeekOrigin.Begin);
+            var rsrcRVA = reader.ReadUInt32();
+            var rsrcSize = reader.ReadUInt32();
+
+            if (rsrcRVA == 0 || rsrcSize == 0) return "0.0.0.0";
+
+            // Section headers: find the section containing the resource RVA
+            fs.Seek(optHeaderStart + optHeaderSize, SeekOrigin.Begin);
+            uint rsrcFileOffset = 0;
+            for (int i = 0; i < numSections; i++)
+            {
+                reader.ReadBytes(8); // Name
+                reader.ReadUInt32(); // VirtualSize
+                var va = reader.ReadUInt32(); // VirtualAddress
+                var rawSize = reader.ReadUInt32();
+                var rawOffset = reader.ReadUInt32();
+                reader.ReadBytes(16); // Rest of section header
+
+                if (va <= rsrcRVA && rsrcRVA < va + rawSize)
+                {
+                    rsrcFileOffset = rawOffset + (rsrcRVA - va);
+                    break;
+                }
+            }
+
+            if (rsrcFileOffset == 0) return "0.0.0.0";
+
+            // Read resource section (cap at 4 MB — version resources are tiny)
+            fs.Seek(rsrcFileOffset, SeekOrigin.Begin);
+            var rsrcData = reader.ReadBytes((int)Math.Min(rsrcSize, 4 * 1024 * 1024));
+
+            // Search for VS_FIXEDFILEINFO magic: FEEF04BD
+            for (int i = 0; i <= rsrcData.Length - 20; i++)
+            {
+                if (rsrcData[i] != 0xBD || rsrcData[i + 1] != 0x04 ||
+                    rsrcData[i + 2] != 0xEF || rsrcData[i + 3] != 0xFE) continue;
+
+                // Offset +4: dwStrucVersion must be 0x00010000 (version 1.0)
+                var structVer = BitConverter.ToUInt32(rsrcData, i + 4);
+                if (structVer != 0x00010000) continue;
+
+                var ms = BitConverter.ToUInt32(rsrcData, i + 8);  // dwFileVersionMS
+                var ls = BitConverter.ToUInt32(rsrcData, i + 12); // dwFileVersionLS
+
+                if (ms == 0 && ls == 0) continue;
+
+                return $"{ms >> 16}.{ms & 0xFFFF}.{ls >> 16}.{ls & 0xFFFF}";
+            }
+        }
+        catch { }
+
+        return "0.0.0.0";
     }
 
     private sealed class AnalysisCacheEntry

--- a/Services/GameScannerService.cs
+++ b/Services/GameScannerService.cs
@@ -18,31 +18,33 @@ using OptiscalerClient.Models;
 using OptiscalerClient.Views;
 using System.Collections.Concurrent;
 using System.IO;
-using System.Runtime.Versioning;
 
 namespace OptiscalerClient.Services;
 
-[SupportedOSPlatform("windows")]
 public class GameScannerService
 {
     private readonly IGameScanner _steamScanner;
-    private readonly IGameScanner _epicScanner;
-    private readonly IGameScanner _gogScanner;
-    private readonly IGameScanner _xboxScanner;
-    private readonly IGameScanner _eaScanner;
-    private readonly IGameScanner _battleNetScanner;
-    private readonly IGameScanner _ubisoftScanner;
+    private readonly IGameScanner? _epicScanner;
+    private readonly IGameScanner? _gogScanner;
+    private readonly IGameScanner? _xboxScanner;
+    private readonly IGameScanner? _eaScanner;
+    private readonly IGameScanner? _battleNetScanner;
+    private readonly IGameScanner? _ubisoftScanner;
     private readonly ExclusionService _exclusions;
 
     public GameScannerService()
     {
         _steamScanner = new SteamScanner();
-        _epicScanner = new EpicScanner();
-        _gogScanner = new GogScanner();
-        _xboxScanner = new XboxScanner();
-        _eaScanner = new EaScanner();
-        _battleNetScanner = new BattleNetScanner();
-        _ubisoftScanner = new UbisoftScanner();
+
+        if (OperatingSystem.IsWindows())
+        {
+            _epicScanner = new EpicScanner();
+            _gogScanner = new GogScanner();
+            _xboxScanner = new XboxScanner();
+            _eaScanner = new EaScanner();
+            _battleNetScanner = new BattleNetScanner();
+            _ubisoftScanner = new UbisoftScanner();
+        }
 
         // config.json lives next to the executable (copied by the build)
         var configPath = Path.Combine(AppContext.BaseDirectory, "config.json");
@@ -77,16 +79,17 @@ public class GameScannerService
 
             if (scanConfig.ScanSteam)
                 platformTasks.Add(Task.Run(() => { try { DebugWindow.Log("[Scanner] Scanning Steam library..."); return _steamScanner.Scan(); } catch (Exception ex) { DebugWindow.Log($"[Scanner] Steam scan error: {ex.Message}"); return new List<Game>(); } }));
-            if (scanConfig.ScanEpic)
+            if (scanConfig.ScanEpic && _epicScanner != null)
                 platformTasks.Add(Task.Run(() => { try { DebugWindow.Log("[Scanner] Scanning Epic Games library..."); return _epicScanner.Scan(); } catch (Exception ex) { DebugWindow.Log($"[Scanner] Epic scan error: {ex.Message}"); return new List<Game>(); } }));
-            if (scanConfig.ScanGOG)
+            if (scanConfig.ScanGOG && _gogScanner != null)
                 platformTasks.Add(Task.Run(() => { try { DebugWindow.Log("[Scanner] Scanning GOG library..."); return _gogScanner.Scan(); } catch (Exception ex) { DebugWindow.Log($"[Scanner] GOG scan error: {ex.Message}"); return new List<Game>(); } }));
-            if (scanConfig.ScanXbox)
+            if (scanConfig.ScanXbox && _xboxScanner != null)
                 platformTasks.Add(Task.Run(() => { try { DebugWindow.Log("[Scanner] Scanning Xbox library (MS Store)..."); return _xboxScanner.Scan(); } catch (Exception ex) { DebugWindow.Log($"[Scanner] Xbox scan error: {ex.Message}"); return new List<Game>(); } }));
-            if (scanConfig.ScanEA)
+            if (scanConfig.ScanEA && _eaScanner != null)
                 platformTasks.Add(Task.Run(() => { try { DebugWindow.Log("[Scanner] Scanning EA App library..."); return _eaScanner.Scan(); } catch (Exception ex) { DebugWindow.Log($"[Scanner] EA scan error: {ex.Message}"); return new List<Game>(); } }));
-            platformTasks.Add(Task.Run(() => { try { DebugWindow.Log("[Scanner] Scanning Battle.net library..."); return _battleNetScanner.Scan(); } catch (Exception ex) { DebugWindow.Log($"[Scanner] Battle.net scan error: {ex.Message}"); return new List<Game>(); } }));
-            if (scanConfig.ScanUbisoft)
+            if (_battleNetScanner != null)
+                platformTasks.Add(Task.Run(() => { try { DebugWindow.Log("[Scanner] Scanning Battle.net library..."); return _battleNetScanner.Scan(); } catch (Exception ex) { DebugWindow.Log($"[Scanner] Battle.net scan error: {ex.Message}"); return new List<Game>(); } }));
+            if (scanConfig.ScanUbisoft && _ubisoftScanner != null)
                 platformTasks.Add(Task.Run(() => { try { DebugWindow.Log("[Scanner] Scanning Ubisoft Connect library..."); return _ubisoftScanner.Scan(); } catch (Exception ex) { DebugWindow.Log($"[Scanner] Ubisoft scan error: {ex.Message}"); return new List<Game>(); } }));
 
             var platformResults = await Task.WhenAll(platformTasks);

--- a/Services/GpuModels.cs
+++ b/Services/GpuModels.cs
@@ -1,0 +1,26 @@
+namespace OptiscalerClient.Services
+{
+    /// <summary>
+    /// GPU vendor types
+    /// </summary>
+    public enum GpuVendor
+    {
+        Unknown,
+        NVIDIA,
+        AMD,
+        Intel
+    }
+
+    /// <summary>
+    /// Information about a detected GPU
+    /// </summary>
+    public class GpuInfo
+    {
+        public string Name { get; set; } = string.Empty;
+        public GpuVendor Vendor { get; set; } = GpuVendor.Unknown;
+        public string DriverVersion { get; set; } = string.Empty;
+        public ulong VideoMemoryBytes { get; set; }
+
+        public string VideoMemoryGB => $"{VideoMemoryBytes / (1024.0 * 1024.0 * 1024.0):F1} GB";
+    }
+}

--- a/Services/LinuxGpuDetectionService.cs
+++ b/Services/LinuxGpuDetectionService.cs
@@ -1,0 +1,206 @@
+using System.Diagnostics;
+using System.Runtime.Versioning;
+using System.Text.RegularExpressions;
+
+namespace OptiscalerClient.Services;
+
+[SupportedOSPlatform("linux")]
+public class LinuxGpuDetectionService : IGpuDetectionService
+{
+    public GpuInfo[] DetectGPUs()
+    {
+        try
+        {
+            var gpus = new List<GpuInfo>();
+            const string drmPath = "/sys/class/drm";
+
+            if (!Directory.Exists(drmPath))
+                return Array.Empty<GpuInfo>();
+
+            foreach (var cardDir in Directory.GetDirectories(drmPath, "card*"))
+            {
+                // Only process top-level card entries (card0, card1, ...) not sub-connectors
+                if (!Regex.IsMatch(Path.GetFileName(cardDir), @"^card\d+$"))
+                    continue;
+
+                var devicePath = Path.Combine(cardDir, "device");
+                if (!Directory.Exists(devicePath)) continue;
+
+                var vendorFile = Path.Combine(devicePath, "vendor");
+                if (!File.Exists(vendorFile)) continue;
+
+                var vendorId = File.ReadAllText(vendorFile).Trim().ToLowerInvariant();
+                var vendor = vendorId switch
+                {
+                    "0x10de" => GpuVendor.NVIDIA,
+                    "0x1002" => GpuVendor.AMD,
+                    "0x8086" => GpuVendor.Intel,
+                    _ => GpuVendor.Unknown
+                };
+
+                if (vendor == GpuVendor.Unknown) continue;
+
+                var gpu = new GpuInfo
+                {
+                    Vendor = vendor,
+                    Name = GetGpuName(devicePath, vendor),
+                    VideoMemoryBytes = GetVram(devicePath, vendor),
+                    DriverVersion = GetDriverVersion(vendor)
+                };
+
+                gpus.Add(gpu);
+            }
+
+            return gpus.ToArray();
+        }
+        catch
+        {
+            return Array.Empty<GpuInfo>();
+        }
+    }
+
+    private string GetGpuName(string devicePath, GpuVendor vendor)
+    {
+        try
+        {
+            var vendorIdRaw = File.ReadAllText(Path.Combine(devicePath, "vendor")).Trim();
+            var deviceIdRaw = File.Exists(Path.Combine(devicePath, "device"))
+                ? File.ReadAllText(Path.Combine(devicePath, "device")).Trim()
+                : "";
+
+            var shortVendor = vendorIdRaw.Replace("0x", "").PadLeft(4, '0');
+            var shortDevice = deviceIdRaw.Replace("0x", "").PadLeft(4, '0');
+
+            var output = RunProcess("lspci", $"-d {shortVendor}:{shortDevice} -mm", timeoutMs: 2000);
+            if (!string.IsNullOrWhiteSpace(output))
+            {
+                var parts = Regex.Matches(output, "\"([^\"]*)\"");
+                if (parts.Count >= 3)
+                    return $"{parts[1].Groups[1].Value} {parts[2].Groups[1].Value}".Trim();
+            }
+        }
+        catch { }
+
+        return vendor switch
+        {
+            GpuVendor.NVIDIA => "NVIDIA GPU",
+            GpuVendor.AMD => "AMD GPU",
+            GpuVendor.Intel => "Intel GPU",
+            _ => "Unknown GPU"
+        };
+    }
+
+    private ulong GetVram(string devicePath, GpuVendor vendor)
+    {
+        // AMD exposes VRAM size directly via sysfs
+        if (vendor == GpuVendor.AMD)
+        {
+            var vramFile = Path.Combine(devicePath, "mem_info_vram_total");
+            if (File.Exists(vramFile) && ulong.TryParse(File.ReadAllText(vramFile).Trim(), out var vram))
+                return vram;
+        }
+
+        // NVIDIA: query via nvidia-smi (returns MiB)
+        if (vendor == GpuVendor.NVIDIA)
+        {
+            var output = RunProcess("nvidia-smi", "--query-gpu=memory.total --format=csv,noheader,nounits", timeoutMs: 3000);
+            if (ulong.TryParse(output?.Trim(), out var mb))
+                return mb * 1024 * 1024;
+        }
+
+        return 0;
+    }
+
+    private string GetDriverVersion(GpuVendor vendor)
+    {
+        if (vendor == GpuVendor.NVIDIA)
+        {
+            var output = RunProcess("nvidia-smi", "--query-gpu=driver_version --format=csv,noheader", timeoutMs: 3000);
+            if (!string.IsNullOrWhiteSpace(output))
+                return output.Trim();
+        }
+
+        var modulePath = vendor switch
+        {
+            GpuVendor.AMD => "/sys/module/amdgpu/version",
+            GpuVendor.Intel => "/sys/module/i915/version",
+            _ => null
+        };
+
+        if (modulePath != null && File.Exists(modulePath))
+            return File.ReadAllText(modulePath).Trim();
+
+        return "Unknown";
+    }
+
+    private string? RunProcess(string fileName, string args, int timeoutMs)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo(fileName, args)
+            {
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using var proc = Process.Start(psi);
+            if (proc == null) return null;
+            var output = proc.StandardOutput.ReadLine();
+            proc.WaitForExit(timeoutMs);
+            return output;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public GpuInfo? GetPrimaryGPU()
+    {
+        var gpus = DetectGPUs();
+        return gpus.Length > 0 ? gpus[0] : null;
+    }
+
+    public GpuInfo? GetDiscreteGPU()
+    {
+        var gpus = DetectGPUs();
+        var discreteGpus = gpus.Where(g => g.VideoMemoryBytes > 2L * 1024 * 1024 * 1024).ToArray();
+
+        if (discreteGpus.Length == 0)
+            return gpus.Length > 0 ? gpus[0] : null;
+
+        return discreteGpus.FirstOrDefault(g => g.Vendor == GpuVendor.NVIDIA)
+            ?? discreteGpus.FirstOrDefault(g => g.Vendor == GpuVendor.AMD)
+            ?? discreteGpus[0];
+    }
+
+    public bool HasGPU(GpuVendor vendor)
+    {
+        return DetectGPUs().Any(g => g.Vendor == vendor);
+    }
+
+    public string GetGPUDescription()
+    {
+        var gpus = DetectGPUs();
+
+        if (gpus.Length == 0)
+            return "No GPU detected";
+
+        if (gpus.Length == 1)
+            return $"{GetVendorIcon(gpus[0].Vendor)} {gpus[0].Name}";
+
+        var discrete = GetDiscreteGPU();
+        if (discrete != null)
+            return $"{GetVendorIcon(discrete.Vendor)} {discrete.Name} (+{gpus.Length - 1} more)";
+
+        return $"{gpus.Length} GPUs detected";
+    }
+
+    private static string GetVendorIcon(GpuVendor vendor) => vendor switch
+    {
+        GpuVendor.NVIDIA => "🟢",
+        GpuVendor.AMD => "🔴",
+        GpuVendor.Intel => "🔵",
+        _ => "⚪"
+    };
+}

--- a/Services/SteamScanner.cs
+++ b/Services/SteamScanner.cs
@@ -3,13 +3,11 @@ using OptiscalerClient.Models;
 using OptiscalerClient.Views;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
 
 namespace OptiscalerClient.Services;
 
-[SupportedOSPlatform("windows")]
 public class SteamScanner : IGameScanner
 {
     private const string REGISTRY_PATH = @"SOFTWARE\Valve\Steam";
@@ -57,6 +55,14 @@ public class SteamScanner : IGameScanner
 
     private string? GetSteamInstallPath()
     {
+        if (OperatingSystem.IsWindows())
+            return GetSteamInstallPathWindows();
+        return GetSteamInstallPathLinux();
+    }
+
+    [SupportedOSPlatform("windows")]
+    private string? GetSteamInstallPathWindows()
+    {
         try
         {
             // Try 32-bit registry view first (Steam is usually 32-bit app)
@@ -71,6 +77,19 @@ public class SteamScanner : IGameScanner
         }
     }
 
+    private string? GetSteamInstallPathLinux()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var candidates = new[]
+        {
+            Path.Combine(home, ".steam", "steam"),
+            Path.Combine(home, ".local", "share", "Steam"),
+            Path.Combine(home, ".var", "app", "com.valvesoftware.Steam", ".local", "share", "Steam"),
+            Path.Combine(home, "snap", "steam", "common", ".steam", "steam"),
+        };
+        return candidates.FirstOrDefault(p => Directory.Exists(Path.Combine(p, "steamapps")));
+    }
+
     private List<string> GetLibraryFolders(string steamPath)
     {
         var folders = new List<string> { steamPath }; // Default library is always the install path
@@ -81,17 +100,16 @@ public class SteamScanner : IGameScanner
         try
         {
             var content = File.ReadAllText(vdfPath);
-            // Regex to find "path" "C:\\..."
-            // VDF format uses "path" <tab/space> "value"
+            // Regex to find "path" "..."
             var matches = Regex.Matches(content, "\"path\"\\s+\"([^\"]+)\"");
 
             foreach (Match match in matches)
             {
                 if (match.Success && match.Groups.Count > 1)
                 {
-                    // Unescape backslashes (VDF escapes them as \\)
+                    // Unescape backslashes (VDF escapes them as \\ on Windows)
                     var path = match.Groups[1].Value.Replace("\\\\", "\\");
-                    if (!folders.Contains(path, StringComparer.OrdinalIgnoreCase))
+                    if (!folders.Contains(path, StringComparer.Ordinal))
                     {
                         folders.Add(path);
                     }
@@ -125,14 +143,7 @@ public class SteamScanner : IGameScanner
             if (!installDirMatch.Success) return null;
 
             var installDirName = installDirMatch.Groups[1].Value;
-            var libraryPath = Path.GetDirectoryName(Path.GetDirectoryName(manifestPath)); // Go up from steamapps/appmanifest_... to library root?
-            // Actually manifest is in steamapps, game is in steamapps/common/
-
-            // The libraryPath in GetLibraryFolders returns the root (e.g. C:\Steam).
-            // manifestPath is C:\Steam\steamapps\appmanifest_123.acf
-            // Game path is C:\Steam\steamapps\common\GameName
-
-            var steamappsPath = Path.GetDirectoryName(manifestPath); // ...\steamapps
+            var steamappsPath = Path.GetDirectoryName(manifestPath); // .../steamapps
             if (steamappsPath == null) return null;
 
             var commonPath = Path.Combine(steamappsPath, "common");

--- a/Services/SteamScanner.cs
+++ b/Services/SteamScanner.cs
@@ -90,29 +90,37 @@ public class SteamScanner : IGameScanner
         return candidates.FirstOrDefault(p => Directory.Exists(Path.Combine(p, "steamapps")));
     }
 
+    private static string CanonicalPath(string path)
+    {
+        try { return new DirectoryInfo(path).ResolveLinkTarget(true)?.FullName ?? Path.GetFullPath(path); }
+        catch { return Path.GetFullPath(path); }
+    }
+
     private List<string> GetLibraryFolders(string steamPath)
     {
-        var folders = new List<string> { steamPath }; // Default library is always the install path
-        var vdfPath = Path.Combine(steamPath, "steamapps", "libraryfolders.vdf");
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var folders = new List<string>();
 
+        var canonical = CanonicalPath(steamPath);
+        seen.Add(canonical);
+        folders.Add(canonical);
+
+        var vdfPath = Path.Combine(steamPath, "steamapps", "libraryfolders.vdf");
         if (!File.Exists(vdfPath)) return folders;
 
         try
         {
             var content = File.ReadAllText(vdfPath);
-            // Regex to find "path" "..."
             var matches = Regex.Matches(content, "\"path\"\\s+\"([^\"]+)\"");
 
             foreach (Match match in matches)
             {
                 if (match.Success && match.Groups.Count > 1)
                 {
-                    // Unescape backslashes (VDF escapes them as \\ on Windows)
                     var path = match.Groups[1].Value.Replace("\\\\", "\\");
-                    if (!folders.Contains(path, StringComparer.Ordinal))
-                    {
-                        folders.Add(path);
-                    }
+                    var canon = CanonicalPath(path);
+                    if (seen.Add(canon))
+                        folders.Add(canon);
                 }
             }
         }

--- a/Services/WindowsGpuDetectionService.cs
+++ b/Services/WindowsGpuDetectionService.cs
@@ -5,30 +5,6 @@ using System.Runtime.Versioning;
 namespace OptiscalerClient.Services
 {
     /// <summary>
-    /// GPU vendor types
-    /// </summary>
-    public enum GpuVendor
-    {
-        Unknown,
-        NVIDIA,
-        AMD,
-        Intel
-    }
-
-    /// <summary>
-    /// Information about a detected GPU
-    /// </summary>
-    public class GpuInfo
-    {
-        public string Name { get; set; } = string.Empty;
-        public GpuVendor Vendor { get; set; } = GpuVendor.Unknown;
-        public string DriverVersion { get; set; } = string.Empty;
-        public ulong VideoMemoryBytes { get; set; }
-
-        public string VideoMemoryGB => $"{VideoMemoryBytes / (1024.0 * 1024.0 * 1024.0):F1} GB";
-    }
-
-    /// <summary>
     /// Service to detect GPU information using WMI
     /// </summary>
     [SupportedOSPlatform("windows")]

--- a/Views/BulkInstallWindow.axaml.cs
+++ b/Views/BulkInstallWindow.axaml.cs
@@ -62,13 +62,11 @@ public partial class BulkInstallWindow : Window
 
         // Initialize GPU service
         if (OperatingSystem.IsWindows())
-        {
             _gpuService = new WindowsGpuDetectionService();
-        }
+        else if (OperatingSystem.IsLinux())
+            _gpuService = new LinuxGpuDetectionService();
         else
-        {
             _gpuService = null!;
-        }
 
         // Populate games list
         foreach (var game in games.OrderBy(g => g.Name))
@@ -758,7 +756,7 @@ public partial class BulkInstallWindow : Window
 
         // Determine default selection
         bool isRdna4 = false;
-        if (OperatingSystem.IsWindows() && _gpuService != null)
+        if (_gpuService != null)
         {
             try
             {

--- a/Views/ConfirmDialog.axaml
+++ b/Views/ConfirmDialog.axaml
@@ -57,8 +57,8 @@
                                 BorderThickness="0"
                                 CornerRadius="0,12,0,0"
                                 Click="BtnCancel_Click">
-                            <TextBlock Text="&#xE711;"
-                                       FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets, Segoe UI"
+                            <TextBlock Text="{OnPlatform '&#xE711;', Linux='✕'}"
+                                       FontFamily="{OnPlatform 'Segoe Fluent Icons, Segoe MDL2 Assets, Segoe UI', Linux='sans-serif'}"
                                        FontSize="12"/>
                         </Button>
                     </Grid>

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -192,6 +192,7 @@
                  <Grid.RowDefinitions>
                      <RowDefinition Height="Auto"/>
                      <RowDefinition Height="Auto"/>
+                     <RowDefinition Height="Auto"/>
                      <RowDefinition Height="*"/>
                      <RowDefinition Height="Auto"/>
                  </Grid.RowDefinitions>
@@ -396,9 +397,31 @@
                      </Grid>
                  </Border>
 
+                 <!-- Linux Steam-only notice -->
+                 <Border Name="LinuxNotice"
+                         Grid.Row="2"
+                         IsVisible="False"
+                         Background="#1A3B6B"
+                         BorderBrush="#2E5FA3"
+                         BorderThickness="0,0,0,1"
+                         Padding="24,10">
+                     <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                         <TextBlock Text="&#xE783;"
+                                    FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets, Segoe UI"
+                                    FontSize="16"
+                                    Foreground="#90B8F8"
+                                    VerticalAlignment="Center"/>
+                         <TextBlock Text="{DynamicResource TxtLinuxSteamOnlyNotice}"
+                                    Foreground="#C8DEFF"
+                                    FontSize="13"
+                                    VerticalAlignment="Center"
+                                    TextWrapping="Wrap"/>
+                     </StackPanel>
+                 </Border>
+
                  <!-- Game List -->
                  <ScrollViewer Name="GameListScrollViewer"
-                               Grid.Row="2"
+                               Grid.Row="3"
                                VerticalScrollBarVisibility="Auto"
                                HorizontalScrollBarVisibility="Disabled"
                                PointerWheelChanged="GameListScrollViewer_PointerWheelChanged">
@@ -707,7 +730,7 @@
 
                  <!-- Game Grid -->
                  <ScrollViewer Name="GameGridScrollViewer"
-                               Grid.Row="2"
+                               Grid.Row="3"
                                VerticalScrollBarVisibility="Auto"
                                HorizontalScrollBarVisibility="Disabled"
                                PointerWheelChanged="GameListScrollViewer_PointerWheelChanged"
@@ -994,7 +1017,7 @@
                  </ScrollViewer>
 
                  <!-- Status Bar -->
-                 <Border Grid.Row="3"
+                 <Border Grid.Row="4"
                          Background="{StaticResource BrBgDeep}"
                          BorderBrush="{StaticResource BrBorderSubtle}"
                          BorderThickness="0,1,0,0"
@@ -1007,7 +1030,7 @@
 
                  <!-- Ghost canvas: floating drag visuals sit here, above all content -->
                  <Canvas Name="DragGhostCanvas"
-                         Grid.Row="0" Grid.RowSpan="4"
+                         Grid.Row="0" Grid.RowSpan="5"
                          IsHitTestVisible="False"
                          ZIndex="100"/>
 

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -117,26 +117,17 @@ namespace OptiscalerClient.Views
         public MainWindow()
         {
             InitializeComponent();
-            if (OperatingSystem.IsWindows())
-            {
-                _scannerService = new GameScannerService();
-            }
-            else
-            {
-                _scannerService = null!; // TODO: Implement Linux game scanner
-            }
+            _scannerService = new GameScannerService();
             _persistenceService = new GamePersistenceService();
             _componentService = new ComponentManagementService();
             _metadataService = new GameMetadataService(_componentService);
             App.ChangeLanguage(_componentService.Config.Language);
             if (OperatingSystem.IsWindows())
-            {
                 _gpuService = new WindowsGpuDetectionService();
-            }
+            else if (OperatingSystem.IsLinux())
+                _gpuService = new LinuxGpuDetectionService();
             else
-            {
-                _gpuService = null!; // TODO: Implement Linux GPU detection
-            }
+                _gpuService = null!;
             _games = new ObservableCollection<Game>();
 
             // Debug Window check
@@ -210,6 +201,10 @@ namespace OptiscalerClient.Views
                 bool hadSavedGames = LoadSavedGames(_windowLifetimeCts.Token);
                 _ = LoadGpuInfoAsync();
                 _ = ScheduleStartupUpdatesAsync(_windowLifetimeCts.Token);
+
+                var linuxNotice = this.FindControl<Border>("LinuxNotice");
+                if (linuxNotice != null)
+                    linuxNotice.IsVisible = OperatingSystem.IsLinux();
 
                 UpdateAnimationsState(_componentService.Config.AnimationsEnabled);
 
@@ -2394,7 +2389,7 @@ namespace OptiscalerClient.Views
             var autoItem = new ComboBoxItem { Content = "Auto (Recommended)", Tag = "auto" };
             cmb.Items.Add(autoItem);
 
-            if (OperatingSystem.IsWindows() && _gpuService != null)
+            if (_gpuService != null)
             {
                 var gpus = _gpuService.DetectGPUs();
                 foreach (var gpu in gpus)
@@ -4037,7 +4032,7 @@ namespace OptiscalerClient.Views
             try
             {
                 List<Game> scanResults;
-                if (OperatingSystem.IsWindows() && _scannerService != null)
+                if (_scannerService != null)
                 {
                     var allowedDrives = _componentService.Config.ScanDriveRoots;
                     scanResults = await _scannerService.ScanAllGamesAsync(
@@ -4717,7 +4712,7 @@ namespace OptiscalerClient.Views
                     _txtGpuInfo!.Text = GetResourceString("TxtDefaultGpu", "Detecting GPU...");
                     gpu = await Task.Run(() =>
                     {
-                        if (OperatingSystem.IsWindows() && _gpuService != null)
+                        if (_gpuService != null)
                         {
                             try
                             {

--- a/Views/ManageGameWindow.axaml
+++ b/Views/ManageGameWindow.axaml
@@ -196,8 +196,8 @@
                                         Classes="IconBtn"
                                         VerticalAlignment="Top"
                                         Click="BtnClose_Click">
-                                    <TextBlock Text="&#xE711;"
-                                               FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets, Segoe UI"
+                                    <TextBlock Text="{OnPlatform '&#xE711;', Linux='✕'}"
+                                               FontFamily="{OnPlatform 'Segoe Fluent Icons, Segoe MDL2 Assets, Segoe UI', Linux='sans-serif'}"
                                                FontSize="12"/>
                                 </Button>
                             </Grid>

--- a/Views/ManageGameWindow.axaml.cs
+++ b/Views/ManageGameWindow.axaml.cs
@@ -173,13 +173,11 @@ namespace OptiscalerClient.Views
             }
 
             if (OperatingSystem.IsWindows())
-            {
                 _gpuService = new WindowsGpuDetectionService();
-            }
+            else if (OperatingSystem.IsLinux())
+                _gpuService = new LinuxGpuDetectionService();
             else
-            {
                 _gpuService = null!;
-            }
 
             SetupUI();
 
@@ -430,7 +428,7 @@ namespace OptiscalerClient.Views
 
             // Determine default selection
             bool isRdna4 = false;
-            if (OperatingSystem.IsWindows() && _gpuService != null)
+            if (_gpuService != null)
             {
                 try
                 {
@@ -863,8 +861,10 @@ namespace OptiscalerClient.Views
                     return;
                 }
 
-                // Robust way on Windows
-                Process.Start("explorer.exe", $"\"{dirToOpen}\"");
+                if (OperatingSystem.IsWindows())
+                    Process.Start("explorer.exe", $"\"{dirToOpen}\"");
+                else
+                    Process.Start(new ProcessStartInfo("xdg-open", dirToOpen) { UseShellExecute = false });
             }
             catch (Exception ex)
             {
@@ -1519,7 +1519,7 @@ namespace OptiscalerClient.Views
         {
             var componentService = new ComponentManagementService();
             GpuInfo? gpu = null;
-            if (OperatingSystem.IsWindows() && _gpuService != null)
+            if (_gpuService != null)
             {
                 gpu = GpuSelectionHelper.GetPreferredGpu(_gpuService, componentService.Config.DefaultGpuId);
             }

--- a/Views/ManageGameWindow.axaml.cs
+++ b/Views/ManageGameWindow.axaml.cs
@@ -864,7 +864,11 @@ namespace OptiscalerClient.Views
                 if (OperatingSystem.IsWindows())
                     Process.Start("explorer.exe", $"\"{dirToOpen}\"");
                 else
-                    Process.Start(new ProcessStartInfo("xdg-open", dirToOpen) { UseShellExecute = false });
+                {
+                    var psi = new ProcessStartInfo("xdg-open") { UseShellExecute = false };
+                    psi.ArgumentList.Add(dirToOpen);
+                    Process.Start(psi);
+                }
             }
             catch (Exception ex)
             {

--- a/Views/ManageScanSourcesWindow.axaml
+++ b/Views/ManageScanSourcesWindow.axaml
@@ -74,31 +74,31 @@
                                         </Grid>
                                         
                                         <!-- Epic Games -->
-                                        <Grid ColumnDefinitions="*,Auto">
+                                        <Grid Name="GridEpic" ColumnDefinitions="*,Auto">
                                             <TextBlock Grid.Column="0" Text="Epic Games" VerticalAlignment="Center" Foreground="{StaticResource BrTextPrimary}"/>
                                             <ToggleSwitch Grid.Column="1" Name="TglEpic" OnContent="" OffContent="" IsChecked="True"/>
                                         </Grid>
-                                        
+
                                         <!-- GOG Galaxy -->
-                                        <Grid ColumnDefinitions="*,Auto">
+                                        <Grid Name="GridGOG" ColumnDefinitions="*,Auto">
                                             <TextBlock Grid.Column="0" Text="GOG Galaxy" VerticalAlignment="Center" Foreground="{StaticResource BrTextPrimary}"/>
                                             <ToggleSwitch Grid.Column="1" Name="TglGOG" OnContent="" OffContent="" IsChecked="True"/>
                                         </Grid>
-                                        
+
                                         <!-- Xbox (Microsoft Store) -->
-                                        <Grid ColumnDefinitions="*,Auto">
+                                        <Grid Name="GridXbox" ColumnDefinitions="*,Auto">
                                             <TextBlock Grid.Column="0" Text="Xbox (Microsoft Store)" VerticalAlignment="Center" Foreground="{StaticResource BrTextPrimary}"/>
                                             <ToggleSwitch Grid.Column="1" Name="TglXbox" OnContent="" OffContent="" IsChecked="True"/>
                                         </Grid>
-                                        
+
                                         <!-- EA App -->
-                                        <Grid ColumnDefinitions="*,Auto">
+                                        <Grid Name="GridEA" ColumnDefinitions="*,Auto">
                                             <TextBlock Grid.Column="0" Text="EA App" VerticalAlignment="Center" Foreground="{StaticResource BrTextPrimary}"/>
                                             <ToggleSwitch Grid.Column="1" Name="TglEA" OnContent="" OffContent="" IsChecked="True"/>
                                         </Grid>
 
                                         <!-- Ubisoft Connect -->
-                                        <Grid ColumnDefinitions="*,Auto">
+                                        <Grid Name="GridUbisoft" ColumnDefinitions="*,Auto">
                                             <TextBlock Grid.Column="0" Text="Ubisoft Connect" VerticalAlignment="Center" Foreground="{StaticResource BrTextPrimary}"/>
                                             <ToggleSwitch Grid.Column="1" Name="TglUbisoft" OnContent="" OffContent="" IsChecked="True"/>
                                         </Grid>

--- a/Views/ManageScanSourcesWindow.axaml.cs
+++ b/Views/ManageScanSourcesWindow.axaml.cs
@@ -75,6 +75,18 @@ namespace OptiscalerClient.Views
             if (tglEA != null) tglEA.IsChecked = config.ScanEA;
             if (tglUbisoft != null) tglUbisoft.IsChecked = config.ScanUbisoft;
 
+            var isWindows = OperatingSystem.IsWindows();
+            var gridEpic = this.FindControl<Grid>("GridEpic");
+            var gridGOG = this.FindControl<Grid>("GridGOG");
+            var gridXbox = this.FindControl<Grid>("GridXbox");
+            var gridEA = this.FindControl<Grid>("GridEA");
+            var gridUbisoft = this.FindControl<Grid>("GridUbisoft");
+            if (gridEpic != null) gridEpic.IsVisible = isWindows;
+            if (gridGOG != null) gridGOG.IsVisible = isWindows;
+            if (gridXbox != null) gridXbox.IsVisible = isWindows;
+            if (gridEA != null) gridEA.IsVisible = isWindows;
+            if (gridUbisoft != null) gridUbisoft.IsVisible = isWindows;
+
             _customFolders.Clear();
             _customFolders.AddRange(config.CustomFolders);
             RefreshCustomFoldersList();


### PR DESCRIPTION
## Summary

- Add Linux platform support with Steam-only game scanning
- Show informational (non-blocking) banner in the UI when running on Linux
- Update README to reflect partial Linux support

## What changed

### Core Linux support
- **`SteamScanner`**: detect Steam via standard Linux paths (`~/.steam`, `~/.local/share/Steam`, Flatpak, Snap)
- **`GameScannerService`**: remove Windows-only restriction; skip non-Steam scanners on Linux
- **`LinuxGpuDetectionService`**: detect GPU via `/sys/class/drm`, `lspci`, `nvidia-smi`
- **`GameAnalyzerService`**: PE binary parser for DLL version detection on Linux
- **`AppUpdateService`**: generate `update.sh` for Linux alongside `update.bat`
- **`ManageGameWindow`**: use `xdg-open` instead of `explorer.exe` on Linux
- **`ConfirmDialog` / `ManageGameWindow`**: use `OnPlatform` for close icon (Segoe font unavailable on Linux)

### UI notice (Linux)
- Informational banner shown at the top of the Games view when the app starts on Linux
- Text: *"Running on Linux: only Steam games are detected automatically. Other platforms are not supported."*
- Non-blocking — does not interrupt any workflow

### README
- Added Linux (Steam) platform badge
- Updated requirements section: Windows 10/11 fully supported; Linux supported with Steam-only scanning
- Updated Auto-Scanner feature description to note the Linux limitation

## Limitation

> **Linux**: only Steam is scanned automatically. Epic Games, GOG, EA, Ubisoft, Battle.net, and Xbox are not supported on Linux.

## How to test

1. Run the app on a Linux machine with Steam installed
2. Click **Scan Games** — Steam titles should be detected
3. Confirm the blue informational banner appears at the top of the Games view
4. Confirm no banner appears when running on Windows