### PR TITLE
fix(linux): exclude Proton and SteamLinuxRuntime dirs from scan

### DIFF
--- a/Services/ExclusionService.cs
+++ b/Services/ExclusionService.cs
@@ -83,7 +83,13 @@ public class ExclusionService
     /// </summary>
     private static List<ScanExclusion> DefaultExclusions() =>
     [
-        new() { Name = "Wallpaper Engine",                    PathSegment = "wallpaper_engine"   },
-        new() { Name = "Steamworks Common Redistributables",  PathSegment = "Steamworks Shared"  }
+        new() { Name = "Wallpaper Engine",                    PathSegment = "wallpaper_engine"          },
+        new() { Name = "Steamworks Common Redistributables",  PathSegment = "Steamworks Shared"         },
+        new() {                                               PathSegment = "SteamLinuxRuntime"         },
+        new() {                                               PathSegment = "common/Proton "            },
+        new() {                                               PathSegment = "Proton - "                 },
+        new() {                                               PathSegment = "Proton Hotfix"             },
+        new() {                                               PathSegment = "Proton EasyAntiCheat Runtime" },
+        new() {                                               PathSegment = "Proton BattlEye Runtime"   },
     ];
 }

--- a/config.json
+++ b/config.json
@@ -39,7 +39,13 @@
         {
             "Name": "GameSave",
             "PathSegment": "GameSave"
-        }
+        },
+        { "PathSegment": "SteamLinuxRuntime" },
+        { "PathSegment": "common/Proton " },
+        { "PathSegment": "Proton - " },
+        { "PathSegment": "Proton Hotfix" },
+        { "PathSegment": "Proton EasyAntiCheat Runtime" },
+        { "PathSegment": "Proton BattlEye Runtime" }
     ],
     "SteamGridDBApiKey": "",
     "Debug": false


### PR DESCRIPTION
## Problem

On Linux, Steam library scans pick up Proton runtimes and SteamLinuxRuntime directories as if they were games (e.g. *Proton - Experimental*, *SteamLinuxRuntime Sniper*, *Proton EasyAntiCheat Runtime*).

## Changes

- `Services/ExclusionService.cs` — added six `PathSegment` entries to `DefaultExclusions()` covering all known naming patterns
- `config.json` — mirrored the same entries in `ScanExclusions` so the fix works with or without a user config on disk

## Patterns covered

| PathSegment | Matches |
|-------------|---------|
| `SteamLinuxRuntime` | SteamLinuxRuntime Soldier, Sniper, etc. |
| `common/Proton ` | Versioned Proton (e.g. `common/Proton 9.0`) |
| `Proton - ` | Named variants (Proton - Experimental) |
| `Proton Hotfix` | Proton Hotfix |
| `Proton EasyAntiCheat Runtime` | EAC runtime |
| `Proton BattlEye Runtime` | BattlEye runtime |

## Test plan

- [ ] Scan Steam library on Linux — no Proton/SteamLinuxRuntime entries appear in game list
- [ ] Build with `dotnet build` → 0 errors, 0 warnings