### PR TITLE
fix: upscaler-DLL filter + Proton/SteamLinuxRuntime exclusions

### DIFF
--- a/Languages/Strings.de.axaml
+++ b/Languages/Strings.de.axaml
@@ -178,6 +178,8 @@
     <x:String x:Key="TxtCustomFolders">Benutzerdefinierte Ordner</x:String>
     <x:String x:Key="TxtAddFolder">+ Ordner hinzufügen</x:String>
     <x:String x:Key="TxtNoCustomFolders">Noch keine benutzerdefinierten Ordner hinzugefügt.</x:String>
+    <x:String x:Key="TxtFilterOptions">Filteroptionen</x:String>
+    <x:String x:Key="TxtShowNonGameApps">Spiele ohne Upscaler anzeigen (DLSS/FSR/XeSS)</x:String>
     <x:String x:Key="TxtRemove">Entfernen</x:String>
     <x:String x:Key="TxtSave">Speichern</x:String>
     <x:String x:Key="TxtScanSources">Scan-Quellen</x:String>

--- a/Languages/Strings.en.axaml
+++ b/Languages/Strings.en.axaml
@@ -219,6 +219,8 @@ This version is unavailable for download. Check your internet connection and try
     <x:String x:Key="TxtCustomFolders">Custom Folders</x:String>
     <x:String x:Key="TxtAddFolder">+ Add Folder</x:String>
     <x:String x:Key="TxtNoCustomFolders">No custom folders added yet.</x:String>
+    <x:String x:Key="TxtFilterOptions">Filter Options</x:String>
+    <x:String x:Key="TxtShowNonGameApps">Show games without upscalers (DLSS/FSR/XeSS)</x:String>
     <x:String x:Key="TxtRemove">Remove</x:String>
     <x:String x:Key="TxtSave">Save</x:String>
     <x:String x:Key="TxtScanSources">Scan Sources</x:String>

--- a/Languages/Strings.es.axaml
+++ b/Languages/Strings.es.axaml
@@ -203,6 +203,8 @@ Esta versión no está disponible para descarga. Verificá tu conexión a intern
     <x:String x:Key="TxtCustomFolders">Carpetas personalizadas</x:String>
     <x:String x:Key="TxtAddFolder">+ Agregar carpeta</x:String>
     <x:String x:Key="TxtNoCustomFolders">No se han agregado carpetas personalizadas aún.</x:String>
+    <x:String x:Key="TxtFilterOptions">Opciones de filtro</x:String>
+    <x:String x:Key="TxtShowNonGameApps">Mostrar juegos sin upscalers (DLSS/FSR/XeSS)</x:String>
     <x:String x:Key="TxtRemove">Eliminar</x:String>
     <x:String x:Key="TxtSave">Guardar</x:String>
     <x:String x:Key="TxtScanSources">Fuentes de escaneo</x:String>

--- a/Languages/Strings.fr.axaml
+++ b/Languages/Strings.fr.axaml
@@ -178,6 +178,8 @@
     <x:String x:Key="TxtCustomFolders">Dossiers personnalisés</x:String>
     <x:String x:Key="TxtAddFolder">+ Ajouter un dossier</x:String>
     <x:String x:Key="TxtNoCustomFolders">Aucun dossier personnalisé ajouté pour le moment.</x:String>
+    <x:String x:Key="TxtFilterOptions">Options de filtre</x:String>
+    <x:String x:Key="TxtShowNonGameApps">Afficher les jeux sans upscalers (DLSS/FSR/XeSS)</x:String>
     <x:String x:Key="TxtRemove">Supprimer</x:String>
     <x:String x:Key="TxtSave">Enregistrer</x:String>
     <x:String x:Key="TxtScanSources">Sources d'analyse</x:String>

--- a/Languages/Strings.it.axaml
+++ b/Languages/Strings.it.axaml
@@ -178,6 +178,8 @@
     <x:String x:Key="TxtCustomFolders">Cartelle personalizzate</x:String>
     <x:String x:Key="TxtAddFolder">+ Aggiungi cartella</x:String>
     <x:String x:Key="TxtNoCustomFolders">Nessuna cartella personalizzata aggiunta ancora.</x:String>
+    <x:String x:Key="TxtFilterOptions">Opzioni filtro</x:String>
+    <x:String x:Key="TxtShowNonGameApps">Mostra giochi senza upscaler (DLSS/FSR/XeSS)</x:String>
     <x:String x:Key="TxtRemove">Rimuovi</x:String>
     <x:String x:Key="TxtSave">Salva</x:String>
     <x:String x:Key="TxtScanSources">Fonti di scansione</x:String>

--- a/Languages/Strings.ja.axaml
+++ b/Languages/Strings.ja.axaml
@@ -178,6 +178,8 @@
     <x:String x:Key="TxtCustomFolders">カスタムフォルダー</x:String>
     <x:String x:Key="TxtAddFolder">+ フォルダーを追加</x:String>
     <x:String x:Key="TxtNoCustomFolders">カスタムフォルダーはまだ追加されていません。</x:String>
+    <x:String x:Key="TxtFilterOptions">フィルターオプション</x:String>
+    <x:String x:Key="TxtShowNonGameApps">アップスケーラーのないゲームを表示（DLSS/FSR/XeSS）</x:String>
     <x:String x:Key="TxtRemove">削除</x:String>
     <x:String x:Key="TxtSave">保存</x:String>
     <x:String x:Key="TxtScanSources">スキャンソース</x:String>

--- a/Languages/Strings.ko.axaml
+++ b/Languages/Strings.ko.axaml
@@ -178,6 +178,8 @@
     <x:String x:Key="TxtCustomFolders">사용자 지정 폴더</x:String>
     <x:String x:Key="TxtAddFolder">+ 폴더 추가</x:String>
     <x:String x:Key="TxtNoCustomFolders">아직 사용자 지정 폴더가 추가되지 않았습니다.</x:String>
+    <x:String x:Key="TxtFilterOptions">필터 옵션</x:String>
+    <x:String x:Key="TxtShowNonGameApps">업스케일러 없는 게임 표시 (DLSS/FSR/XeSS)</x:String>
     <x:String x:Key="TxtRemove">제거</x:String>
     <x:String x:Key="TxtSave">저장</x:String>
     <x:String x:Key="TxtScanSources">스캔 소스</x:String>

--- a/Languages/Strings.nl.axaml
+++ b/Languages/Strings.nl.axaml
@@ -196,6 +196,8 @@
     <x:String x:Key="TxtCustomFolders">Aangepaste mappen</x:String>
     <x:String x:Key="TxtAddFolder">+ Map toevoegen</x:String>
     <x:String x:Key="TxtNoCustomFolders">Nog geen aangepaste mappen toegevoegd.</x:String>
+    <x:String x:Key="TxtFilterOptions">Filteropties</x:String>
+    <x:String x:Key="TxtShowNonGameApps">Spellen zonder upscalers weergeven (DLSS/FSR/XeSS)</x:String>
     <x:String x:Key="TxtRemove">Verwijderen</x:String>
     <x:String x:Key="TxtSave">Opslaan</x:String>
     <x:String x:Key="TxtScanSources">Scanbronnen</x:String>

--- a/Languages/Strings.pl.axaml
+++ b/Languages/Strings.pl.axaml
@@ -178,6 +178,8 @@
     <x:String x:Key="TxtCustomFolders">Niestandardowe foldery</x:String>
     <x:String x:Key="TxtAddFolder">+ Dodaj folder</x:String>
     <x:String x:Key="TxtNoCustomFolders">Nie dodano jeszcze żadnych niestandardowych folderów.</x:String>
+    <x:String x:Key="TxtFilterOptions">Opcje filtrowania</x:String>
+    <x:String x:Key="TxtShowNonGameApps">Pokaż gry bez upscalerów (DLSS/FSR/XeSS)</x:String>
     <x:String x:Key="TxtRemove">Usuń</x:String>
     <x:String x:Key="TxtSave">Zapisz</x:String>
     <x:String x:Key="TxtScanSources">Źródła skanowania</x:String>

--- a/Languages/Strings.pt-BR.axaml
+++ b/Languages/Strings.pt-BR.axaml
@@ -194,6 +194,8 @@
     <x:String x:Key="TxtCustomFolders">Pastas personalizadas</x:String>
     <x:String x:Key="TxtAddFolder">+ Adicionar pasta</x:String>
     <x:String x:Key="TxtNoCustomFolders">Nenhuma pasta personalizada adicionada ainda.</x:String>
+    <x:String x:Key="TxtFilterOptions">Opções de Filtro</x:String>
+    <x:String x:Key="TxtShowNonGameApps">Mostrar jogos sem upscalers (DLSS/FSR/XeSS)</x:String>
     <x:String x:Key="TxtRemove">Remover</x:String>
     <x:String x:Key="TxtSave">Salvar</x:String>
     <x:String x:Key="TxtScanSources">Fontes de verificação</x:String>

--- a/Languages/Strings.ru.axaml
+++ b/Languages/Strings.ru.axaml
@@ -178,6 +178,8 @@
     <x:String x:Key="TxtCustomFolders">Пользовательские папки</x:String>
     <x:String x:Key="TxtAddFolder">+ Добавить папку</x:String>
     <x:String x:Key="TxtNoCustomFolders">Пользовательские папки еще не добавлены.</x:String>
+    <x:String x:Key="TxtFilterOptions">Параметры фильтра</x:String>
+    <x:String x:Key="TxtShowNonGameApps">Показать игры без апскейлеров (DLSS/FSR/XeSS)</x:String>
     <x:String x:Key="TxtRemove">Удалить</x:String>
     <x:String x:Key="TxtSave">Сохранить</x:String>
     <x:String x:Key="TxtScanSources">Источники сканирования</x:String>

--- a/Languages/Strings.tr.axaml
+++ b/Languages/Strings.tr.axaml
@@ -178,6 +178,8 @@
     <x:String x:Key="TxtCustomFolders">Özel klasörler</x:String>
     <x:String x:Key="TxtAddFolder">+ Klasör ekle</x:String>
     <x:String x:Key="TxtNoCustomFolders">Henüz özel klasör eklenmedi.</x:String>
+    <x:String x:Key="TxtFilterOptions">Filtre Seçenekleri</x:String>
+    <x:String x:Key="TxtShowNonGameApps">Upscaler'sız oyunları göster (DLSS/FSR/XeSS)</x:String>
     <x:String x:Key="TxtRemove">Kaldır</x:String>
     <x:String x:Key="TxtSave">Kaydet</x:String>
     <x:String x:Key="TxtScanSources">Tarama kaynakları</x:String>

--- a/Languages/Strings.zh-CN.axaml
+++ b/Languages/Strings.zh-CN.axaml
@@ -178,6 +178,8 @@
     <x:String x:Key="TxtCustomFolders">自定义文件夹</x:String>
     <x:String x:Key="TxtAddFolder">+ 添加文件夹</x:String>
     <x:String x:Key="TxtNoCustomFolders">尚未添加自定义文件夹。</x:String>
+    <x:String x:Key="TxtFilterOptions">筛选选项</x:String>
+    <x:String x:Key="TxtShowNonGameApps">显示没有升频器的游戏（DLSS/FSR/XeSS）</x:String>
     <x:String x:Key="TxtRemove">移除</x:String>
     <x:String x:Key="TxtSave">保存</x:String>
     <x:String x:Key="TxtScanSources">扫描源</x:String>

--- a/Languages/Strings.zh-TW.axaml
+++ b/Languages/Strings.zh-TW.axaml
@@ -178,6 +178,8 @@
     <x:String x:Key="TxtCustomFolders">自訂資料夾</x:String>
     <x:String x:Key="TxtAddFolder">+ 新增資料夾</x:String>
     <x:String x:Key="TxtNoCustomFolders">尚未新增自訂資料夾。</x:String>
+    <x:String x:Key="TxtFilterOptions">篩選選項</x:String>
+    <x:String x:Key="TxtShowNonGameApps">顯示沒有升頻器的遊戲（DLSS/FSR/XeSS）</x:String>
     <x:String x:Key="TxtRemove">移除</x:String>
     <x:String x:Key="TxtSave">儲存</x:String>
     <x:String x:Key="TxtScanSources">掃描來源</x:String>

--- a/Models/AppConfiguration.cs
+++ b/Models/AppConfiguration.cs
@@ -40,6 +40,7 @@ namespace OptiscalerClient.Models
         public bool ScanEA { get; set; } = true;
         public bool ScanUbisoft { get; set; } = true;
         public List<string> CustomFolders { get; set; } = new();
+        public bool ShowNonGameEntries { get; set; } = false;
     }
 
     /// <summary>

--- a/Models/Game.cs
+++ b/Models/Game.cs
@@ -57,6 +57,8 @@ public class Game
     public string? OptiscalerVersion { get; set; }
     public string? Fsr4ExtraVersion { get; set; }
 
+    public bool HasUpscaler => DlssVersion != null || DlssFrameGenVersion != null || FsrVersion != null || XessVersion != null || IsOptiscalerInstalled;
+
     // UI customization (not set by scanner)
     public bool IsHidden { get; set; } = false;
     public int DisplayOrder { get; set; } = 0;

--- a/Services/ExclusionService.cs
+++ b/Services/ExclusionService.cs
@@ -84,6 +84,9 @@ public class ExclusionService
     private static List<ScanExclusion> DefaultExclusions() =>
     [
         new() { Name = "Wallpaper Engine",                    PathSegment = "wallpaper_engine"   },
-        new() { Name = "Steamworks Common Redistributables",  PathSegment = "Steamworks Shared"  }
+        new() { Name = "Steamworks Common Redistributables",  PathSegment = "Steamworks Shared"  },
+        new() { Name = "SteamVR",                             PathSegment = "SteamVR"            },
+        new() { Name = "Steam Linux Runtime",                 PathSegment = "SteamLinuxRuntime"  },
+        new() { Name = "Proton",                              PathSegment = "Proton "            }
     ];
 }

--- a/Services/GameAnalyzerService.cs
+++ b/Services/GameAnalyzerService.cs
@@ -365,6 +365,7 @@ public class GameAnalyzerService
                     }
                     list.Add(file);
                 }
+
             }
         }
         catch (Exception ex)

--- a/Services/GameScannerService.cs
+++ b/Services/GameScannerService.cs
@@ -129,8 +129,12 @@ public class GameScannerService
 
             GameAnalyzerService.FlushCacheToDisk();
 
-            DebugWindow.Log($"[Scanner] Scan completed. Found {games.Count} valid games.");
-            return games.OrderBy(g => g.Platform).ThenBy(g => g.Name).ToList();
+            var filtered = scanConfig.ShowNonGameEntries
+                ? games
+                : games.Where(g => g.HasUpscaler || g.Platform == GamePlatform.Custom);
+
+            DebugWindow.Log($"[Scanner] Scan completed. Found {filtered.Count()} games (ShowNonGameEntries={scanConfig.ShowNonGameEntries}).");
+            return filtered.OrderBy(g => g.Platform).ThenBy(g => g.Name).ToList();
         });
     }
 

--- a/Views/ManageScanSourcesWindow.axaml
+++ b/Views/ManageScanSourcesWindow.axaml
@@ -106,6 +106,25 @@
                                     </StackPanel>
                                 </Border>
 
+                                <!-- Filter Options -->
+                                <TextBlock Text="{DynamicResource TxtFilterOptions}"
+                                           FontWeight="SemiBold"
+                                           FontSize="14"
+                                           Foreground="{StaticResource BrTextPrimary}"
+                                           Margin="0,0,0,12"/>
+
+                                <Border Background="{StaticResource BrBgCard}"
+                                        BorderBrush="{StaticResource BrBorderSubtle}"
+                                        BorderThickness="1"
+                                        CornerRadius="{StaticResource RadiusMedium}"
+                                        Padding="16,12"
+                                        Margin="0,0,0,24">
+                                    <Grid ColumnDefinitions="*,Auto">
+                                        <TextBlock Grid.Column="0" Text="{DynamicResource TxtShowNonGameApps}" VerticalAlignment="Center" Foreground="{StaticResource BrTextPrimary}" TextWrapping="Wrap"/>
+                                        <ToggleSwitch Grid.Column="1" Name="TglShowNonGameApps" OnContent="" OffContent="" IsChecked="False"/>
+                                    </Grid>
+                                </Border>
+
                                 <!-- Custom Folders -->
                                 <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,12">
                                     <TextBlock Grid.Column="0"

--- a/Views/ManageScanSourcesWindow.axaml.cs
+++ b/Views/ManageScanSourcesWindow.axaml.cs
@@ -75,6 +75,9 @@ namespace OptiscalerClient.Views
             if (tglEA != null) tglEA.IsChecked = config.ScanEA;
             if (tglUbisoft != null) tglUbisoft.IsChecked = config.ScanUbisoft;
 
+            var tglShowNonGameApps = this.FindControl<ToggleSwitch>("TglShowNonGameApps");
+            if (tglShowNonGameApps != null) tglShowNonGameApps.IsChecked = config.ShowNonGameEntries;
+
             var isWindows = OperatingSystem.IsWindows();
             var gridEpic = this.FindControl<Grid>("GridEpic");
             var gridGOG = this.FindControl<Grid>("GridGOG");
@@ -208,6 +211,8 @@ namespace OptiscalerClient.Views
             var tglEA = this.FindControl<ToggleSwitch>("TglEA");
             var tglUbisoft = this.FindControl<ToggleSwitch>("TglUbisoft");
 
+            var tglShowNonGameApps = this.FindControl<ToggleSwitch>("TglShowNonGameApps");
+
             _componentService.Config.ScanSources.ScanSteam = tglSteam?.IsChecked ?? true;
             _componentService.Config.ScanSources.ScanEpic = tglEpic?.IsChecked ?? true;
             _componentService.Config.ScanSources.ScanGOG = tglGOG?.IsChecked ?? true;
@@ -215,6 +220,7 @@ namespace OptiscalerClient.Views
             _componentService.Config.ScanSources.ScanEA = tglEA?.IsChecked ?? true;
             _componentService.Config.ScanSources.ScanUbisoft = tglUbisoft?.IsChecked ?? true;
             _componentService.Config.ScanSources.CustomFolders = _customFolders.ToList();
+            _componentService.Config.ScanSources.ShowNonGameEntries = tglShowNonGameApps?.IsChecked ?? false;
 
             _componentService.SaveConfiguration();
             Close(true);

--- a/config.json
+++ b/config.json
@@ -39,6 +39,18 @@
         {
             "Name": "GameSave",
             "PathSegment": "GameSave"
+        },
+        {
+            "Name": "SteamVR",
+            "PathSegment": "SteamVR"
+        },
+        {
+            "Name": "Steam Linux Runtime",
+            "PathSegment": "SteamLinuxRuntime"
+        },
+        {
+            "Name": "Proton",
+            "PathSegment": "Proton "
         }
     ],
     "SteamGridDBApiKey": "",


### PR DESCRIPTION
## Summary

- **Replaces graphics-runtime heuristic with upscaler-DLL filter**: the previous approach matched games by presence of `d3d9/d3d11/dxgi/UnityPlayer` etc., which caused false positives (e.g. Sekiro — DX11 but no DLSS/FSR/XeSS). Games are now shown only when the analyzer detects `nvngx_dlss.dll`, `libxess.dll`, or an FSR2+/FidelityFX DLL — the actual hooks OptiScaler needs. `HasGraphicsRuntime` removed; `HasUpscaler` is a computed property derived from the already-collected version fields (no extra scan pass).
- **Toggle label updated in all 14 locales**: "Show games without upscalers (DLSS/FSR/XeSS)" to reflect the new semantics.
- **Proton and Steam Linux Runtime exclusions simplified**: six granular entries replaced with three broader `PathSegment` patterns (`"Proton "`, `"SteamLinuxRuntime"`, `"SteamVR"`), mirrored in both `ExclusionService.DefaultExclusions()` and `config.json`.

## Test plan

- [ ] Scan Steam library: games with DLSS/FSR/XeSS appear; games without (e.g. Sekiro, purely DX11 titles) are hidden by default
- [ ] Enable "Show games without upscalers" toggle — previously hidden games appear
- [ ] Custom-folder entries appear regardless of upscaler presence
- [ ] Proton, SteamLinuxRuntime and SteamVR directories do not appear in scan results
- [ ] Games already with OptiScaler installed (`IsOptiscalerInstalled = true`) appear even without a native upscaler DLL