### PR TITLE
Add Heroic Games Launcher Support

### DIFF
--- a/Models/AppConfiguration.cs
+++ b/Models/AppConfiguration.cs
@@ -71,6 +71,7 @@ namespace OptiscalerClient.Models
     public class ScanSourcesConfig
     {
         public bool ScanSteam { get; set; } = true;
+        public bool ScanHeroic { get; set; } = true;
         public bool ScanEpic { get; set; } = true;
         public bool ScanGOG { get; set; } = true;
         public bool ScanXbox { get; set; } = true;

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 ### Game Discovery
 
-- **Multi-Platform Auto-Scanner** — Scans **Steam, Epic Games, GOG, EA, Ubisoft, Battle.net, and Xbox/Microsoft Store** libraries in parallel. On Linux, only Steam is scanned automatically.
+- **Multi-Platform Auto-Scanner** — Scans **Steam, Epic Games, GOG, EA, Ubisoft, Battle.net, Heroic, and Xbox/Microsoft Store** libraries in parallel. On Linux, only **Steam** and **Heroic** (Epic Games, GOG) are scanned automatically.
 - **Custom Folder Scanning** — Add any folder as a scan source for DRM-free or standalone games.
 - **Manual Game Addition** — Add games by selecting the executable directly.
 - **Drive Root Filtering** — Limit scanning to specific drives.
@@ -150,7 +150,7 @@ Full interface translation in **14 languages**:
 ### Notes
 
 - The app is self-contained, so no external .NET runtime installation is required.
-- On Linux, automatic scanner sources are focused on Steam libraries.
+- On Linux, automatic scanner sources are focused on Steam and Heroic libraries.
 - Manual add/install flows currently target executable files (`.exe`) for game selection.
 
 ---

--- a/Services/GameScannerService.cs
+++ b/Services/GameScannerService.cs
@@ -24,6 +24,7 @@ namespace OptiscalerClient.Services;
 public class GameScannerService
 {
     private readonly IGameScanner _steamScanner;
+    private readonly IGameScanner _heroicScanner;
     private readonly IGameScanner? _epicScanner;
     private readonly IGameScanner? _gogScanner;
     private readonly IGameScanner? _xboxScanner;
@@ -35,6 +36,7 @@ public class GameScannerService
     public GameScannerService()
     {
         _steamScanner = new SteamScanner();
+        _heroicScanner = new HeroicScanner();
 
         if (OperatingSystem.IsWindows())
         {
@@ -79,6 +81,8 @@ public class GameScannerService
 
             if (scanConfig.ScanSteam)
                 platformTasks.Add(Task.Run(() => { try { DebugWindow.Log("[Scanner] Scanning Steam library..."); return _steamScanner.Scan(); } catch (Exception ex) { DebugWindow.Log($"[Scanner] Steam scan error: {ex.Message}"); return new List<Game>(); } }));
+            if (scanConfig.ScanHeroic)
+                platformTasks.Add(Task.Run(() => { try { DebugWindow.Log("[Scanner] Scanning Heroic library..."); return _heroicScanner.Scan(); } catch (Exception ex) { DebugWindow.Log($"[Scanner] Heroic scan error: {ex.Message}"); return new List<Game>(); } }));
             if (scanConfig.ScanEpic && _epicScanner != null)
                 platformTasks.Add(Task.Run(() => { try { DebugWindow.Log("[Scanner] Scanning Epic Games library..."); return _epicScanner.Scan(); } catch (Exception ex) { DebugWindow.Log($"[Scanner] Epic scan error: {ex.Message}"); return new List<Game>(); } }));
             if (scanConfig.ScanGOG && _gogScanner != null)

--- a/Services/HeroicScanner.cs
+++ b/Services/HeroicScanner.cs
@@ -1,0 +1,127 @@
+using System.Runtime.Versioning;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OptiscalerClient.Models;
+
+namespace OptiscalerClient.Services;
+
+public class HeroicScanner : IGameScanner
+{
+	private class HeroicGame
+	{
+	    [JsonPropertyName("appName")]
+	    public string AppId { get; set; } = string.Empty;
+	    [JsonPropertyName("app_name")]
+		private string AppId2 { set { AppId = value; } }
+	    [JsonPropertyName("title")]
+	    public string? Title { get; set; }
+	    [JsonPropertyName("install_path")]
+	    public string InstallPath { get; set; } = string.Empty;
+	    [JsonPropertyName("executable")]
+	    public string Executable { get; set; } = string.Empty;
+	    [JsonPropertyName("platform")]
+	    public string OsPlatform { get; set; } = string.Empty;
+	    [JsonPropertyName("is_dlc")]
+	    public bool IsDlc { get; set; }
+		public GamePlatform? GamePlatform { get; set; }
+	}
+
+	public List<Game> Scan()
+	{
+		var games = new List<Game>();
+
+		try
+		{
+			var heroicGames = new List<HeroicGame>();
+
+			var heroicDataPaths = GetHeroicDataPaths();
+			foreach (var dataPath in heroicDataPaths)
+			{
+				if (!Path.Exists(dataPath)) continue;
+
+				var heroicGogDataPath = Path.Combine(dataPath, "gog_store", "installed.json");
+				var heroicEpicDataPath = Path.Combine(dataPath, "legendaryConfig", "legendary", "installed.json");
+
+				// GOG
+				if (Path.Exists(heroicGogDataPath))
+				{
+					var gogJson = File.ReadAllText(heroicGogDataPath);
+					var gogGamesDict = JsonSerializer.Deserialize<Dictionary<string, List<HeroicGame>>>(gogJson)!;
+					var gogGames = gogGamesDict.First().Value;
+					foreach (var game in gogGames)
+						game.GamePlatform = GamePlatform.GOG;
+					heroicGames.AddRange(gogGames);
+				}
+
+				// Epic
+				if (Path.Exists(heroicEpicDataPath))
+				{
+					var epicJson = File.ReadAllText(heroicEpicDataPath);
+					var epicGamesDict = JsonSerializer.Deserialize<Dictionary<string, HeroicGame>>(epicJson)!;
+					var epicGames = new List<HeroicGame>();
+					foreach (var game in epicGamesDict)
+						epicGames.Add(game.Value);
+					foreach (var game in epicGames)
+						game.GamePlatform = GamePlatform.Epic;
+					heroicGames.AddRange(epicGames);
+				}
+			}
+
+			foreach (var game in heroicGames)
+			{
+				if (game.IsDlc || game.GamePlatform == null
+					|| game.OsPlatform.ToLower() != "windows")
+						continue;
+
+				var gameName = string.Empty;
+				if (game.GamePlatform == GamePlatform.Epic)
+					gameName = game.Title;
+				else
+					gameName = game.InstallPath.Split(Path.DirectorySeparatorChar).Last();
+
+				if (Path.Exists(game.InstallPath) && !string.IsNullOrEmpty(gameName))
+				{
+					games.Add(new Game
+					{
+						AppId = game.AppId,
+						Name = gameName,
+						InstallPath = game.InstallPath,
+						Platform = game.GamePlatform.Value
+					});
+				}
+			}
+		}
+		catch (Exception ex)
+		{
+            System.Diagnostics.Debug.WriteLine($"[Heroic] Error scanning: {ex.Message}");
+		}
+
+        return games;
+	}
+
+	private string[] GetHeroicDataPaths()
+	{
+		if (OperatingSystem.IsWindows())
+			return GetHeroicDataPathsWindows();
+		return GetHeroicDataPathsLinux();
+	}
+
+	[SupportedOSPlatform("windows")]
+	private string[] GetHeroicDataPathsWindows()
+	{
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+		var heroicDataPath = Path.Combine(appData, "heroic");
+		return [heroicDataPath];
+	}
+
+	private string[] GetHeroicDataPathsLinux()
+	{
+		var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+		var dataPaths = new[]
+		{
+			Path.Combine(home, ".config", "heroic"),
+		    Path.Combine(home, ".var", "app", "com.heroicgameslauncher.hgl", "config", "heroic"),
+		};
+		return dataPaths;
+	}
+}

--- a/Views/InitialScanPromptWindow.axaml
+++ b/Views/InitialScanPromptWindow.axaml
@@ -228,6 +228,10 @@
                                             <TextBlock Grid.Column="0" Text="Steam" VerticalAlignment="Center" Foreground="{StaticResource BrTextPrimary}"/>
                                             <ToggleSwitch Grid.Column="1" Name="TglSteam" OnContent="" OffContent="" IsChecked="True"/>
                                         </Grid>
+                                        <Grid Name="GridHeroic" ColumnDefinitions="*,Auto">
+                                            <TextBlock Grid.Column="0" Text="Heroic" VerticalAlignment="Center" Foreground="{StaticResource BrTextPrimary}"/>
+                                            <ToggleSwitch Grid.Column="1" Name="TglHeroic" OnContent="" OffContent="" IsChecked="True"/>
+                                        </Grid>
                                         <!-- Windows-only sources; visibility set from code-behind -->
                                         <Grid Name="GridEpic" ColumnDefinitions="*,Auto">
                                             <TextBlock Grid.Column="0" Text="Epic Games" VerticalAlignment="Center" Foreground="{StaticResource BrTextPrimary}"/>

--- a/Views/InitialScanPromptWindow.axaml.cs
+++ b/Views/InitialScanPromptWindow.axaml.cs
@@ -85,6 +85,7 @@ namespace OptiscalerClient.Views
             var config = _componentService.Config.ScanSources;
 
             var tglSteam = this.FindControl<ToggleSwitch>("TglSteam");
+            var tglHeroic = this.FindControl<ToggleSwitch>("TglHeroic");
             var tglEpic = this.FindControl<ToggleSwitch>("TglEpic");
             var tglGOG = this.FindControl<ToggleSwitch>("TglGOG");
             var tglXbox = this.FindControl<ToggleSwitch>("TglXbox");
@@ -92,6 +93,7 @@ namespace OptiscalerClient.Views
             var tglUbisoft = this.FindControl<ToggleSwitch>("TglUbisoft");
 
             if (tglSteam != null) tglSteam.IsChecked = config.ScanSteam;
+            if (tglHeroic != null) tglHeroic.IsChecked = config.ScanHeroic;
             if (tglEpic != null) tglEpic.IsChecked = config.ScanEpic;
             if (tglGOG != null) tglGOG.IsChecked = config.ScanGOG;
             if (tglXbox != null) tglXbox.IsChecked = config.ScanXbox;
@@ -404,6 +406,7 @@ namespace OptiscalerClient.Views
         private void BtnStartScan_Click(object? sender, RoutedEventArgs e)
         {
             var tglSteam = this.FindControl<ToggleSwitch>("TglSteam");
+            var tglHeroic = this.FindControl<ToggleSwitch>("TglHeroic");
             var tglEpic = this.FindControl<ToggleSwitch>("TglEpic");
             var tglGOG = this.FindControl<ToggleSwitch>("TglGOG");
             var tglXbox = this.FindControl<ToggleSwitch>("TglXbox");
@@ -413,6 +416,7 @@ namespace OptiscalerClient.Views
             var sources = new ScanSourcesConfig
             {
                 ScanSteam = tglSteam?.IsChecked ?? true,
+                ScanHeroic = tglHeroic?.IsChecked ?? true,
                 ScanEpic = tglEpic?.IsChecked ?? true,
                 ScanGOG = tglGOG?.IsChecked ?? true,
                 ScanXbox = tglXbox?.IsChecked ?? true,

--- a/Views/ManageScanSourcesWindow.axaml
+++ b/Views/ManageScanSourcesWindow.axaml
@@ -73,6 +73,12 @@
                                             <ToggleSwitch Grid.Column="1" Name="TglSteam" OnContent="" OffContent="" IsChecked="True"/>
                                         </Grid>
                                         
+                                        <!-- Heroic -->
+                                        <Grid Name="GridHeroic" ColumnDefinitions="*,Auto">
+                                            <TextBlock Grid.Column="0" Text="Heroic" VerticalAlignment="Center" Foreground="{StaticResource BrTextPrimary}"/>
+                                            <ToggleSwitch Grid.Column="1" Name="TglHeroic" OnContent="" OffContent="" IsChecked="True"/>
+                                        </Grid>
+
                                         <!-- Epic Games -->
                                         <Grid Name="GridEpic" ColumnDefinitions="*,Auto">
                                             <TextBlock Grid.Column="0" Text="Epic Games" VerticalAlignment="Center" Foreground="{StaticResource BrTextPrimary}"/>

--- a/Views/ManageScanSourcesWindow.axaml.cs
+++ b/Views/ManageScanSourcesWindow.axaml.cs
@@ -65,6 +65,7 @@ namespace OptiscalerClient.Views
             var config = _componentService.Config.ScanSources;
 
             var tglSteam = this.FindControl<ToggleSwitch>("TglSteam");
+            var tglHeroic = this.FindControl<ToggleSwitch>("TglHeroic");
             var tglEpic = this.FindControl<ToggleSwitch>("TglEpic");
             var tglGOG = this.FindControl<ToggleSwitch>("TglGOG");
             var tglXbox = this.FindControl<ToggleSwitch>("TglXbox");
@@ -72,6 +73,7 @@ namespace OptiscalerClient.Views
             var tglUbisoft = this.FindControl<ToggleSwitch>("TglUbisoft");
 
             if (tglSteam != null) tglSteam.IsChecked = config.ScanSteam;
+            if (tglHeroic != null) tglHeroic.IsChecked = config.ScanHeroic;
             if (tglEpic != null) tglEpic.IsChecked = config.ScanEpic;
             if (tglGOG != null) tglGOG.IsChecked = config.ScanGOG;
             if (tglXbox != null) tglXbox.IsChecked = config.ScanXbox;
@@ -227,6 +229,7 @@ namespace OptiscalerClient.Views
         private void BtnSave_Click(object? sender, RoutedEventArgs e)
         {
             var tglSteam = this.FindControl<ToggleSwitch>("TglSteam");
+            var tglHeroic = this.FindControl<ToggleSwitch>("TglHeroic");
             var tglEpic = this.FindControl<ToggleSwitch>("TglEpic");
             var tglGOG = this.FindControl<ToggleSwitch>("TglGOG");
             var tglXbox = this.FindControl<ToggleSwitch>("TglXbox");
@@ -234,6 +237,7 @@ namespace OptiscalerClient.Views
             var tglUbisoft = this.FindControl<ToggleSwitch>("TglUbisoft");
 
             _componentService.Config.ScanSources.ScanSteam = tglSteam?.IsChecked ?? true;
+            _componentService.Config.ScanSources.ScanHeroic = tglHeroic?.IsChecked ?? true;
             _componentService.Config.ScanSources.ScanEpic = tglEpic?.IsChecked ?? true;
             _componentService.Config.ScanSources.ScanGOG = tglGOG?.IsChecked ?? true;
             _componentService.Config.ScanSources.ScanXbox = tglXbox?.IsChecked ?? true;


### PR DESCRIPTION
# Summary
- Requires testing under Windows. I only tested under Linux.
- Provides game scanning (Epic Games and GOG) for Heroic Games Launcher under Windows and Linux.
  - It does this by deserializing Heroic's installed.json for both Epic games and GOG games, this gives us a nice list of all the installed games.
- Under Linux it scans both possible Heroic data directories (Native and Flatpak) and includes both results, reasoning is explained below.

### Lacks
- Heroic's Amazon Games Support (should be easy to add)

# Detailed Notes
I'm very surface level on C# so let me know if I did anything outlandish.
I was unsure of where to put the Deserialization class "HeroicGame" so let me know if you'd like me to move it, I saw you are doing some optimization with source generation but I don't think HeroicGame is hooked up to that system atm.

Needs testing on Windows as I only tested under Linux. The only OS specific part is the gathering of the path to the Heroic data directory, everything else *hopefully* should be OS agnostic.

Supports GOG and Epic Games from the Heroic Games Launcher. Heroic's Amazon Games support wasn't included in this PR as the base isn't there for it in the rest of the codebase and I'm unsure if the project wants to support that platform anyway, so I've left it out for now. It should be relatively simple to include support for it on top of this implementation.

Under Linux this scans both the Native data directory (which also includes the AppImage) and the Flatpak data directory and includes both results in the scan (which covers every version of Heroic under Linux). I included both data directories in the scan because I didn't want one to be preferred over the other when it's possible both could be being actively used, this does lead to duplication of game entries when the same game is installed under both of the two different types of Heroic install, however I feel this is preferred instead of a case where an inactive data directory exists and is leftover and we prefer that inactive data directory that the user isn't even using. Still even if there is invalid data leftover in a data directory the HeroicScanner checks if the game path Heroic is leading to exists and disregards the game if it doesn't, this covers the case if an inactive Heroic data directory still thinks a game is installed even though the game directory was manually deleted.

Heroic (mainly it's subprojects) provides a friendly name for Epic games but both GOG and Amazon do not (At least in the file we are fetching here), in which case the Game's name is set to the name of the game's folder, this means the GOG/Amazon game's SteamGridDB fetching are less accurate than Epic games.

Currently it adds the games as GamePlatform.Epic and GamePlatform.GOG but the GamePlatform enum might benefit from having something like GamePlatform.HeroicEpic or GamePlatform.HeroicGOG. Possibly instead of that, having a "Launcher" enum in the Game class so the UI can optionally display what launcher the game entry is from in the case of there being multiple Epic or GOG games installed from different launchers. Something specific to Linux which might help as well is a "launcher type" so the UI can for example: display if it's grabbing a game from the Flatpak version of a launcher.